### PR TITLE
Direct Probability condition

### DIFF
--- a/src/offlinemapmatching/mm/hidden_states/transition.py
+++ b/src/offlinemapmatching/mm/hidden_states/transition.py
@@ -55,6 +55,9 @@ class Transition:
     
         #store the result
         self.direction_probability = p_intermediate
+        
+        if self.points_on_network == -1:
+            self.direction_probability = None
     
     def setRoutingProbability(self, distance_between_observations, beta):
         #get the distance of the shortest path between the two candidates of the current transition

--- a/src/offlinemapmatching/mm/hidden_states/transition.py
+++ b/src/offlinemapmatching/mm/hidden_states/transition.py
@@ -52,8 +52,6 @@ class Transition:
                     
                     #clear the slope
                     m_candidate = 0.0
-        elif self.points_on_network == -1:
-            self.direction_probability = None
     
         #store the result
         self.direction_probability = p_intermediate


### PR DESCRIPTION
Hi @jagodki ,
In order to work the following direct probability computation,
```
if self.points_on_network == -1:
            self.direction_probability = None
```
must be assigned after,
`
self.direction_probability = p_intermediate`

Do you agree?

Regards,
Bruno